### PR TITLE
Fix outlines version to less than `0.2.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai>=2.5.0",
-  "outlines>=0.1.0",
+  "outlines~=0.1.0",
 ]
 [project.optional-dependencies]
 mlxlm = ["outlines[mlxlm]"]


### PR DESCRIPTION
`0.2.0` doesn't support python 3.9